### PR TITLE
Fixes a bug that the RFC4180 output.

### DIFF
--- a/ITURHFProp/Src/ITURHFProp/Report.c
+++ b/ITURHFProp/Src/ITURHFProp/Report.c
@@ -534,6 +534,14 @@ void function_RPT_BMUFD(struct PathData path, struct ITURHFProp ITURHFP, int opt
 			fprintf(fp,",");
 			fprintf(fp, DBLFIELD, path.MUF10);
 			break;
+		case PRINT_RFC4180_DATA:
+			fprintf(fp,",");
+			fprintf(fp, RFC4180_DBLFIELD, path.MUF50);
+			fprintf(fp,",");
+			fprintf(fp, RFC4180_DBLFIELD, path.MUF90);
+			fprintf(fp,",");
+			fprintf(fp, RFC4180_DBLFIELD, path.MUF10);
+			break;
 	};
 
 	return;


### PR DESCRIPTION
Hello Chris,

I left a bug in the changes I made to support RFC4180 CSV files.  I didn't define any output for the MUF deciles output so they were being left blank.  This is now fixed.  The changes shouldn't affect any other part of ITURHFProp. 