### PR TITLE
Fix sscanf usage

### DIFF
--- a/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
+++ b/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
@@ -117,34 +117,46 @@ int ReadInputConfiguration(char InFilePath[256], struct ITURHFProp *ITURHFP, str
 				sscanf(line, "%*s %d", &path->year);
 			};
 			if (strncmp("Path.month", line, 10) == 0) {
-				sscanf(line, "%*s %[^/\n]", &instr);
+				sscanf(line, "%*s %[^/\n]", instr);
 				// If this contains no commas, then it is a single month.
 				if (strchr(instr, ',') == NULL) {
 					sscanf(line, "%*s %d", &ITURHFP->months[0]);
 					ITURHFP->months[0] -= 1;
 				}
 				else {
+					char instr2[256];
+					char *buf[2];
+					int count = 0;
+					buf[0] = instr;
+					buf[1] = instr2;
 					i = 0;
 					retval = 2;
-					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
-						retval = sscanf(instr, "%d, %[0-9 ,]", &ITURHFP->months[i], &instr);
+					while ((strlen(buf[count]) != 0) && (buf[count][0] != '/') && (retval == 2)) {
+						retval = sscanf(buf[count], "%d, %[0-9 ,]", &ITURHFP->months[i], buf[count^1]);
 						ITURHFP->months[i++] -= 1;
+						count ^= 1;
 					};
 				};
 			};
 			if (strncmp("Path.hour", line, 9) == 0) {
-				sscanf(line, "%*s %[^/\n]", &instr);
+				sscanf(line, "%*s %[^/\n]", instr);
 				// If this contains no commas, then it is a single month.
 				if (strchr(instr, ',') == NULL) {
 					sscanf(line, "%*s %d", &ITURHFP->hrs[0]);
 					ITURHFP->hrs[0] -= 1;
 				}
 				else {
+					char instr2[256];
+					char *buf[2];
+					int count = 0;
+					buf[0] = instr;
+					buf[1] = instr2;
 					i = 0;
 					retval = 2;
-					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
-						retval = sscanf(instr, "%d, %[0-9 ,]", &ITURHFP->hrs[i], &instr);
+					while ((strlen(buf[count]) != 0) && (buf[count][0] != '/') && (retval == 2)) {
+						retval = sscanf(buf[count], "%d, %[0-9 ,]", &ITURHFP->hrs[i], buf[count^1]);
 						ITURHFP->hrs[i++] -= 1;
+						count ^= 1; /* swap use of the two buffers */
 					};
 				};
 			};
@@ -152,16 +164,22 @@ int ReadInputConfiguration(char InFilePath[256], struct ITURHFProp *ITURHFP, str
 				sscanf(line, "%*s %d", &path->SSN);
 			};
 			if (strncmp("Path.frequency", line, 14) == 0) {
-				sscanf(line, "%*s %[^/\n]", &instr);
+				sscanf(line, "%*s %[^/\n]", instr);
 				// If this contains no commas, then it is a single month.
 				if (strchr(instr, ',') == NULL) {
 					sscanf(line, "%*s %lf", &ITURHFP->frqs[0]);
 				}
 				else {
+					char instr2[256];
+					char *buf[2];
+					int count = 0;
+					buf[0] = instr;
+					buf[1] = instr2;
 					i = 0;
 					retval = 2;
-					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
-						retval = sscanf(instr, "%lf, %[0-9 ,.]", &ITURHFP->frqs[i++], &instr);
+					while ((strlen(buf[count]) != 0) && (buf[count][0] != '/') && (retval == 2)) {
+						retval = sscanf(buf[count], "%lf, %[0-9 ,.]", &ITURHFP->frqs[i++], buf[count^1]);
+						count ^= 1;
 					};
 				};
 			};
@@ -253,11 +271,17 @@ int ReadInputConfiguration(char InFilePath[256], struct ITURHFProp *ITURHFP, str
 					ITURHFP->RptFileFormat = OutputOption(instr);
 				}
 				else {
+					char instr2[256];
+					char *buf[2];
+					int count = 0;
+					buf[0] = instr;
+					buf[1] = instr2;
 					retval = 2;
 					ITURHFP->RptFileFormat = 0;
-					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
-						retval = sscanf(instr, "%s | %[a-z,A-Z _|]", &optstr, &instr);
+					while ((strlen(buf[count]) != 0) && (buf[count][0] != '/') && (retval == 2)) {
+						retval = sscanf(buf[count], "%s | %[a-z,A-Z _|]", optstr, buf[count^1]);
 						ITURHFP->RptFileFormat = ITURHFP->RptFileFormat | OutputOption(optstr);
+						count ^= 1;
 					};
 				};
 			};

--- a/P533/Src/P533/ReadP1239.c
+++ b/P533/Src/P533/ReadP1239.c
@@ -65,7 +65,7 @@ int ReadP1239(struct PathData *path, const char * DataFilePath) {
 					// Read the next latitude line of text
 					fgets(line, 256, fp);
 					// Scan 1 string latitude and 24 numbers corresponding to hours
-					sscanf(line, "%s %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf/n", &substr, 
+					sscanf(line, "%s %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf/n", substr,
 									&path->foF2var[i][0][k][m][n],  &path->foF2var[i][1][k][m][n],  &path->foF2var[i][2][k][m][n],  &path->foF2var[i][3][k][m][n], 
 									&path->foF2var[i][4][k][m][n],  &path->foF2var[i][5][k][m][n],  &path->foF2var[i][6][k][m][n],  &path->foF2var[i][7][k][m][n],
 									&path->foF2var[i][8][k][m][n],  &path->foF2var[i][9][k][m][n],  &path->foF2var[i][10][k][m][n], &path->foF2var[i][11][k][m][n], 


### PR DESCRIPTION
Compilers (at least gcc and clang) report type errors when converting
using %s and %[...] to pointers to char*. Presumably these are typos
with the intent being to convert into the buffers.

This commit changes those, and also changes the instances where sscanf
is scanning from instr into instr, which might be OK but seems
confusing (and is likely undefined begaviour technically). These are
changed to use two buffers which are used alternately. (Again, I think
that matches the intent though I'm not entirely confident.)