### PR TITLE
fix: About hour manipulation

### DIFF
--- a/ITURHFProp/Src/ITURHFProp/DumpPathData.c
+++ b/ITURHFProp/Src/ITURHFProp/DumpPathData.c
@@ -81,7 +81,7 @@ void DumpPathData(struct PathData path, struct ITURHFProp ITURHFP) {
 	fprintf(fp, "\t%s\n", path.name);
 	fprintf(fp, "\tYear = %d\n", path.year);
 	fprintf(fp, "\tMonth = %s\n", months[path.month]); 
-	fprintf(fp, "\tHour  = %d (hour UTC)\n", path.hour + 1);
+	fprintf(fp, "\tHour  = %d (hour UTC)\n", (path.hour==0?24:path.hour)); // + 1);
 	fprintf(fp, "\tSSN (R12) = %d\n", path.SSN);
 	fprintf(fp, "\tTx power = % 5.3lf (dB(1kW))\n", path.txpower);
 	fprintf(fp, "\tTx Location %s\n", path.txname);
@@ -90,8 +90,8 @@ void DumpPathData(struct PathData path, struct ITURHFProp ITURHFP) {
 	fprintf(fp, "\tRx Location %s\n", path.rxname);
 	fprintf(fp, "\tRx latitude  = % 5.3lf (% 5.3lf) [% d %d %d]\n", path.L_rx.lat, path.L_rx.lat*R2D, degrees(path.L_rx.lat*R2D), minutes(path.L_rx.lat*R2D), seconds(path.L_rx.lat*R2D));
 	fprintf(fp, "\tRx longitude = % 5.3lf (% 5.3lf) [% d %d %d]\n", path.L_rx.lng, path.L_rx.lng*R2D, degrees(path.L_rx.lng*R2D), minutes(path.L_rx.lng*R2D), seconds(path.L_rx.lng*R2D));
-	fprintf(fp, "\tlocal time Rx   = % 02d \n", path.hour + 1 + (int)(path.L_rx.lng/(15.0*D2R)));
-	fprintf(fp, "\tlocal time Tx   = % 02d \n", path.hour + 1 + (int)(path.L_tx.lng/(15.0*D2R)));
+    fprintf(fp, "\tlocal time Rx   = % 02d \n", (path.hour==0?24:path.hour) /* + 1*/ + (int)(path.L_rx.lng/(15.0*D2R)));
+	fprintf(fp, "\tlocal time Tx   = % 02d \n", (path.hour==0?24:path.hour) /* + 1*/ + (int)(path.L_tx.lng/(15.0*D2R)));
 	fprintf(fp, "\tFrequency = % 5.3lf (MHz)\n", path.frequency);
 	fprintf(fp, "\tBandwidth = % 5.3lf (Hz)\n", path.BW);
 	fprintf(fp, "\tShort or Long Path = %s\n", SorL[path.SorL]);

--- a/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
+++ b/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
@@ -256,7 +256,7 @@ int ReadInputConfiguration(char InFilePath[256], struct ITURHFProp *ITURHFP, str
 					retval = 2;
 					ITURHFP->RptFileFormat = 0;
 					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
-						retval = sscanf(instr, "%s | %[a-z,A-Z _|]", &optstr, &instr);
+						retval = sscanf(instr, "%s | %[a-z,A-Z _|02]", &optstr, &instr);
 						ITURHFP->RptFileFormat = ITURHFP->RptFileFormat | OutputOption(optstr);
 					};
 				};

--- a/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
+++ b/ITURHFProp/Src/ITURHFProp/ReadInputConfiguration.c
@@ -137,14 +137,14 @@ int ReadInputConfiguration(char InFilePath[256], struct ITURHFProp *ITURHFP, str
 				// If this contains no commas, then it is a single month.
 				if (strchr(instr, ',') == NULL) {
 					sscanf(line, "%*s %d", &ITURHFP->hrs[0]);
-					ITURHFP->hrs[0] -= 1;
+					ITURHFP->hrs[0] %=24; // -= 1;
 				}
 				else {
 					i = 0;
 					retval = 2;
 					while ((strlen(instr) != 0) && (instr[0] != '/') && (retval == 2)) {
 						retval = sscanf(instr, "%d, %[0-9 ,]", &ITURHFP->hrs[i], &instr);
-						ITURHFP->hrs[i++] -= 1;
+						ITURHFP->hrs[i++] %=24; // -= 1;
 					};
 				};
 			};

--- a/ITURHFProp/Src/ITURHFProp/Report.c
+++ b/ITURHFProp/Src/ITURHFProp/Report.c
@@ -306,7 +306,7 @@ void PrintHeader(struct PathData path, struct ITURHFProp ITURHFP) {
 	fprintf(fp, "\t%s\n", path.name);
 	fprintf(fp, "\tYear          : %d\n", path.year);
 	fprintf(fp, "\tMonth         : %s\n", months[path.month]);
-	fprintf(fp, "\tHour          : %d (hour UTC)\n", path.hour + 1);
+	fprintf(fp, "\tHour          : %d (hour UTC)\n", (path.hour==0?24:path.hour);// + 1);
 	fprintf(fp, "\tSSN (R12)     : %d\n", path.SSN);
 	fprintf(fp, "\tDistance      : %lf (km)\n", path.distance);
 	fprintf(fp, "\tdmax          : %lf (km)\n", path.dmax);
@@ -317,8 +317,8 @@ void PrintHeader(struct PathData path, struct ITURHFProp ITURHFP) {
 	fprintf(fp, "\tRx Location     %s\n", path.rxname);
 	fprintf(fp, "\tRx latitude   : %10.6lf %c\n", fabs(path.L_rx.lat*R2D), NS(path.L_rx.lat));
 	fprintf(fp, "\tRx longitude  : %10.6lf %c\n", fabs(path.L_rx.lng*R2D), EW(path.L_rx.lng));
-	fprintf(fp, "\tlocal time Rx : %d (hour UTC)\n", (int)fmod((path.hour + 1 + (int)(path.L_rx.lng/(15.0*D2R)))+24,24.0));
-	fprintf(fp, "\tlocal time Tx : %d (hour UTC)\n", (int)fmod((path.hour + 1 + (int)(path.L_tx.lng/(15.0*D2R)))+24,24.0));
+	fprintf(fp, "\tlocal time Rx : %d (hour UTC)\n", (int)fmod(((path.hour==0?24:path.hour) /*+ 1*/ + (int)(path.L_rx.lng/(15.0*D2R)))+24,24.0));
+	fprintf(fp, "\tlocal time Tx : %d (hour UTC)\n", (int)fmod(((path.hour==0?24:path.hour) /*+ 1*/ + (int)(path.L_tx.lng/(15.0*D2R)))+24,24.0));
 	fprintf(fp, "\tFrequency     : %lf\n", path.frequency);
 	fprintf(fp, "\tBandwidth     : %lf\n", path.BW);
 

--- a/ITURHFProp/Src/ITURHFProp/Report.c
+++ b/ITURHFProp/Src/ITURHFProp/Report.c
@@ -306,7 +306,7 @@ void PrintHeader(struct PathData path, struct ITURHFProp ITURHFP) {
 	fprintf(fp, "\t%s\n", path.name);
 	fprintf(fp, "\tYear          : %d\n", path.year);
 	fprintf(fp, "\tMonth         : %s\n", months[path.month]);
-	fprintf(fp, "\tHour          : %d (hour UTC)\n", (path.hour==0?24:path.hour);// + 1);
+	fprintf(fp, "\tHour          : %d (hour UTC)\n", (path.hour==0?24:path.hour));// + 1);
 	fprintf(fp, "\tSSN (R12)     : %d\n", path.SSN);
 	fprintf(fp, "\tDistance      : %lf (km)\n", path.distance);
 	fprintf(fp, "\tdmax          : %lf (km)\n", path.dmax);

--- a/ITURHFProp/Src/ITURHFProp/Report.c
+++ b/ITURHFProp/Src/ITURHFProp/Report.c
@@ -177,7 +177,7 @@ void PrintRecord(struct PathData path, struct ITURHFProp ITURHFP, int option) {
 			fprintf(fp, "%02d", path.month+1);
 			fprintf(fp,",");
 			// Hour
-			fprintf(fp, " %02d", path.hour+1);
+			fprintf(fp, " %02d", (path.hour==0?24:path.hour)/*+1*/);
 			fprintf(fp,",");
 			// Frequency
 			fprintf(fp, DBLFIELD3, path.frequency);
@@ -185,7 +185,7 @@ void PrintRecord(struct PathData path, struct ITURHFProp ITURHFP, int option) {
 		case PRINT_RFC4180_DATA:
 			// Each record will require the month, hour, and frequency
 			// Month
-			fprintf(fp, "%d,%d,", path.month+1, path.hour+1);
+			fprintf(fp, "%d,%d,", path.month+1, (path.hour==0?24:path.hour)/*+1*/);
 			fprintf(fp, RFC4180_DBLFIELD, path.frequency);
 			break;
 	};

--- a/P372/Src/ITURNoise/ITURNoise.c
+++ b/P372/Src/ITURNoise/ITURNoise.c
@@ -143,9 +143,9 @@ int main(int argc, char* argv[]) {
 			return RTN_ERRMONTH;
 		};
 
-		hour = atoi(argv[2]) - 1;
+		hour = atoi(argv[2])%24;// - 1;
 		if ((hour < 0) || (hour > 23)) {
-			printf("ITURNoise: Error: Hour (%d (UTC)) Out of Range (1 to 24 UTC) ", hour + 1);
+			printf("ITURNoise: Error: Hour (%d (UTC)) Out of Range (1 to 24 UTC) ", hour /*+ 1*/);
 			return RTN_ERRMONTH;
 		};
 

--- a/P372/Src/P372/MakeNoise.c
+++ b/P372/Src/P372/MakeNoise.c
@@ -141,7 +141,7 @@ void PrintFam(FILE *fp, struct NoiseParams* noiseP, int month, int hour, double 
 	fprintf(fp ,"\tP372 Compile Time: %s\n", P372compt);
 	fprintf(fp ,"**********************************************************\n");
 	fprintf(fp, "\n");
-	fprintf(fp ,"\t%s : %d (UTC) (1 to 24)\n", monthnames[month], hour+1);
+	fprintf(fp ,"\t%s : %d (UTC) (1 to 24)\n", monthnames[month], (hour==0?24:hour)/*+1*/);
 	fprintf(fp, "\t%5.4f (deg lat) %5.4f (deg long)\n", rlat * R2D, rlng * R2D);
 	fprintf(fp, "\t%5.3f (MHz)\n", freq);
 	fprintf(fp, "\n");

--- a/P533/Src/P533/CalculateCPParameters.c
+++ b/P533/Src/P533/CalculateCPParameters.c
@@ -469,7 +469,7 @@ void FindfoE(struct ControlPt *here, int month, int hour, int SSN) {
 	else { // (here->sza >= 90.0*D2R )
 		// In this case local sunset and sunrise must be known.
 		// Find h the number of hours after sunset
-		hour = (hour + 1) % 24; // Adjust time and roll over
+		hour = (hour /*+ 1*/) % 24; // Adjust time and roll over
 		if((here->Sun.lss >= here->Sun.lsr) && (hour >= here->Sun.lss) && (hour >= here->Sun.lsr)) {
 			h = hour - here->Sun.lss;
 		}

--- a/P533/Src/P533/CircuitReliability.c
+++ b/P533/Src/P533/CircuitReliability.c
@@ -589,7 +589,7 @@ double DigitalModulationSignalandInterferers(struct PathData *path, int iS[MAXMD
 				dh = path->distance/(n+1); // Hop distance
 				delta = ElevationAngle(dh, hr);
 				psi = dh/(2.0*R0);
-				ptick = 2.0*R0*(sin(psi)/cos(delta - psi));
+				ptick = 2.0*R0*(sin(psi)/cos(delta + /*-*/ psi));
 				path->Md_E[n].tau = (n+1)*(ptick/VofL)*1000.0;
 			};
 		};
@@ -602,7 +602,7 @@ double DigitalModulationSignalandInterferers(struct PathData *path, int iS[MAXMD
 				dh = path->distance/(n+1); // Hop distance
 				delta = ElevationAngle(dh, hr);
 				psi = dh/(2.0*R0);
-				ptick = 2.0*R0*(sin(psi)/cos(delta - psi));
+				ptick = 2.0*R0*(sin(psi)/cos(delta + /*-*/ psi));
 				path->Md_F2[n].tau = (n+1)*(ptick/VofL)*1000.0;
 			};
 		};

--- a/P533/Src/P533/MedianSkywaveFieldStrengthLong.c
+++ b/P533/Src/P533/MedianSkywaveFieldStrengthLong.c
@@ -662,15 +662,15 @@ void FindfL(struct PathData *path, struct ControlPt CP[MAXCP][24], int hops, dou
 	// Testing
 
 	// Find fL[] for the "present hour" for further calculations 
-	// The "present hour" is calculated at path->hour + 1. 
+	// The "present hour" is calculated at path->hour /*+ 1*/. 
 	// Elsewhere in the code it is assumed that UTC 1 uses the index path->hour = 0
 	// to represent time from 0:00 to 0:59 
 	// In this calculation UTC 1 implies 1:00 to 1:59 UTC so the "present hour" 
-	// is path->hour + 1. 
+	// is path->hour /*+ 1*/. 
 	// This is a consequence of the routine being based on the Fortran program FTZ() 
 	// which of course uses indexing beginning at 1
 	// Find the "present hour" and roll it over if necessary
-	now = (path->hour + 1 + 24) % 24;
+	now = (path->hour /*+ 1*/ + 24) % 24;
 
 	// Set the value of fL[]
 	path->fL = fL[now]; 


### PR DESCRIPTION
The input format of hour is (1-24)UTC. It is maniputed in the following way:
* preprocessing: path.hour = hour - 1
* processing: ...  path.hour
* postprocessing: printf("...%d..."..., path.hour + 1,...)

It is ok for path.hour as an array index, but not for other usages like UTC to LMT or vise versa.

The recommended way is:
* prepocessing:  path.hour = hour % 24
* processing:    path.hour
* postprocessing: (path.hour==0?24:path.hour)