### PR TITLE
Add missing stdlib.h include

### DIFF
--- a/P372/Src/P372/NoiseMemory.c
+++ b/P372/Src/P372/NoiseMemory.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 
 // Local includes
 #include "Common.h"


### PR DESCRIPTION
NoiseMemory uses malloc, so it needs to include stdlib.h. This can cause build failure with some compilers.