### PR TITLE
Allow passing optimization flags into the Makefile

### DIFF
--- a/ITURHFProp/Linux/Makefile
+++ b/ITURHFProp/Linux/Makefile
@@ -2,7 +2,8 @@ CC = gcc
 # Use the following for testing
 #CFLAGS = -fPIC -Wall -Wextra -O0 -g
 # Use the following for production
-CFLAGS = -fPIC -Wall -Wextra -O2
+OPTIMIZE ?= -O2
+CFLAGS = -fPIC -Wall -Wextra $(OPTIMIZE)
 
 LDFLAGS = -lm -ldl -z muldefs
 RM = rm -f

--- a/P372/Linux/Makefile
+++ b/P372/Linux/Makefile
@@ -4,7 +4,8 @@ bin_dir = ../Bin/
 # Use the following for testing
 #CFLAGS = -fPIC -Wall -Wextra -O0 -g -I$(source_dir)
 # Use the following for production
-CFLAGS = -fPIC -Wall -Wextra -O2 -I$(source_dir)
+OPTIMIZE ?= -O2
+CFLAGS = -fPIC -Wall -Wextra $(OPTIMIZE) -I$(source_dir)
 
 LDFLAGS = -shared -lm -ldl -z muldefs
 RM = rm -f

--- a/P533/Linux/Makefile
+++ b/P533/Linux/Makefile
@@ -4,7 +4,8 @@ bin_dir = ../Bin/
 # Use the following for testing
 #CFLAGS = -fPIC -Wall -Wextra -O0 -g -I$(source_dir)
 # Use the following for production
-CFLAGS = -std=c99 -fPIC -Wall -Wextra -O2 -I$(source_dir)
+OPTIMIZE ?= -O2
+CFLAGS = -std=c99 -fPIC -Wall -Wextra $(OPTIMIZE) -I$(source_dir)
 
 LDFLAGS = -shared -lm -ldl -z muldefs
 RM = rm -f


### PR DESCRIPTION
This allows building with optimization flags using something like `make OPTIMIZE=-O3` instead of having to edit the Makefile.